### PR TITLE
Add "version" field to binary tabby-codellama-7B

### DIFF
--- a/coder-tabby-codellama-7b/manifest.json
+++ b/coder-tabby-codellama-7b/manifest.json
@@ -1,6 +1,7 @@
 {
     "id": "tabby-codellama-7B",
     "type": "binary",
+    "version": "1",
     "name": "Tabby CodeLlama 7B",
     "description": "",
     "documentation": "",


### PR DESCRIPTION
The Service schema takes a new "version" field. If not provided we consider the service as legacy.